### PR TITLE
Changed name of modify() function in Employee.js

### DIFF
--- a/src/client/src/models/Employee.js
+++ b/src/client/src/models/Employee.js
@@ -6,7 +6,7 @@ export default class Employee {
         this.email=email;
     }
 
-    modifyEmployee(firstName, lastName, email) {
+    modify(firstName, lastName, email) {
         this.firstName=firstName;
         this.lastName=lastName;
         this.email=email;


### PR DESCRIPTION
This needs to be discussed as it is a naming convention issue, but for now the modify() function in a respective class  will have the name modify(parameterName1, parameterName2)